### PR TITLE
Fix naming mistake with connection_request & connection_reply

### DIFF
--- a/factorio.lua
+++ b/factorio.lua
@@ -345,9 +345,9 @@ function dissect_connection_request(pos, tvbuf, pktinfo, tree)
 	local ver_tree = tree:add(tvbuf:range(pos, 5), "clientApplicationVersion: " .. version)
 	ver_tree:add(pf.connection_request_major_ver, tvbuf:range(pos, 1))
 	pos = pos + 1
-	ver_tree:add(pf.connection_request_major_ver, tvbuf:range(pos, 1))
+	ver_tree:add(pf.connection_request_minor_ver, tvbuf:range(pos, 1))
 	pos = pos + 1
-	ver_tree:add(pf.connection_request_major_ver, tvbuf:range(pos, 1))
+	ver_tree:add(pf.connection_request_patch_ver, tvbuf:range(pos, 1))
 	pos = pos + 1
 	ver_tree:add_le(pf.connection_request_build_ver, tvbuf:range(pos, 2))
 	pos = pos + 2
@@ -380,9 +380,9 @@ function dissect_connection_request_reply(pos, tvbuf, pktinfo, tree)
 	local ver_tree = tree:add(tvbuf:range(pos, 5), "serverApplicationVersion: " .. version)
 	ver_tree:add(pf.connection_reply_major_ver, tvbuf:range(pos, 1))
 	pos = pos + 1
-	ver_tree:add(pf.connection_reply_major_ver, tvbuf:range(pos, 1))
+	ver_tree:add(pf.connection_reply_minor_ver, tvbuf:range(pos, 1))
 	pos = pos + 1
-	ver_tree:add(pf.connection_reply_major_ver, tvbuf:range(pos, 1))
+	ver_tree:add(pf.connection_reply_patch_ver, tvbuf:range(pos, 1))
 	pos = pos + 1
 	ver_tree:add_le(pf.connection_reply_build_ver, tvbuf:range(pos, 2))
 	pos = pos + 2

--- a/factorio.lua
+++ b/factorio.lua
@@ -35,7 +35,7 @@ local ef = {}
 ef.too_short   = ProtoExpert.new("fgp.too_short.expert", "Factorio Game Protocol packet too short", expert.group.MALFORMED, expert.severity.ERROR)
 ef.unknown     = ProtoExpert.new("fgp.unknown.expert", "Factorio Game Protocol unknown packet data", expert.group.UNDECODED, expert.severity.WARN)
 ef.malformed   = ProtoExpert.new("fgp.malformed.expert", "Factorio Game Protocol malformed data", expert.group.MALFORMED, expert.severity.ERROR)
-ef.unnecessary = ProtoExpert.new("fgp.unnecessary.expert", "Factorio Game PRotocol unnecessary encoding", expert.group.PROTOCOL, expert.severity.NOTE)
+ef.unnecessary = ProtoExpert.new("fgp.unnecessary.expert", "Factorio Game Protocol unnecessary encoding", expert.group.PROTOCOL, expert.severity.NOTE)
 
 
 function decode_uint32v(pos, tvbuf)


### PR DESCRIPTION
Fixes a small issue with fields having the wrong name on the connection_request & connection_reply
(reused connection_reply_major_ver instead of connection_reply_minor_ver, connection_reply_patch_ver)

Before:
![image](https://github.com/Hornwitser/factorio_dissector/assets/47361765/8cb30388-acb5-4bb6-b1ac-ca8731ad9fa4)
After:
![image](https://github.com/Hornwitser/factorio_dissector/assets/47361765/f665d872-3e82-4c9c-9055-6ef042e7073b)

(also fixes an unrelated capitalization)